### PR TITLE
Fix for 0.1.52

### DIFF
--- a/src/java.web/defrac/sample/video/VideoSample.java
+++ b/src/java.web/defrac/sample/video/VideoSample.java
@@ -132,7 +132,7 @@ class VideoSample extends GenericApp {
             // allows us to upload the HTMLVideoElement as a texture.
             webGL.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, GL.RGBA, GL.UNSIGNED_BYTE, video);
             try {
-              textureDataGLPair._2.assertNoError();
+              textureDataGLPair.y.assertNoError();
             } catch(Throwable t) {
               window.alert(t.getMessage());
             }


### PR DESCRIPTION
0.1.52 renamed the "_1" and "_2" properties of pair to "x" and "y"
