### PR TITLE
Adopted changes of 0.1.55

### DIFF
--- a/src/java.web/defrac/sample/video/VideoSample.java
+++ b/src/java.web/defrac/sample/video/VideoSample.java
@@ -12,7 +12,7 @@ import defrac.gl.WebGLSubstrate;
 import defrac.lang.Pair;
 import defrac.lang.Procedure;
 import defrac.signal.SignalBinding;
-import intrinsic.*;
+import defrac.web.*;
 
 import javax.annotation.Nonnull;
 import java.lang.Math;


### PR DESCRIPTION
The "intrinsic" package is no more. Instead we are going for "defrac.web.*" now since this is more in align of what the other platforms do.
